### PR TITLE
Group metrics by week and make Activation relative

### DIFF
--- a/app/controllers/retention_magic/graphs_controller.rb
+++ b/app/controllers/retention_magic/graphs_controller.rb
@@ -6,15 +6,15 @@ module RetentionMagic
       # RetentionMagic configuration setup
       @user_class = RetentionMagic.user_class.constantize
 
-
-      first_user = @user_class.order(:created_at).first
-      first_cohort = @first_user.created_at.beginning_of_month
+      @first_user = @user_class.order(:created_at).first
+      first_cohort_week = 12.weeks.ago.to_date.beginning_of_week
       today = Date.today
 
+      difference_in_days_between_now_and_first_cohort = (today.beginning_of_week - first_cohort_week).to_i
+
       # For presenting the widgets
-      @first_cohort_label = first_cohort.strftime("%h %Y")
-      @current_cohort_label = today.strftime("%h %Y")
-      @number_of_months = (today.year * 12 + today.month) - (first_cohort.year * 12 + first_cohort.month)
+      @current_cohort_label = today.strftime("%U/%Y")
+      @number_of_weeks = difference_in_days_between_now_and_first_cohort / 7
 
       @graphs = {
         activation: {
@@ -28,9 +28,9 @@ module RetentionMagic
       retention_models = RetentionMagic.retention_models.map { |class_name| class_name.constantize }
       activation_fields_for_query = RetentionMagic.activation_counter_columns.join(" + ")
 
-      0.upto(@number_of_months - 1) do |month|
-        cohort_start = @first_user.created_at.beginning_of_month + month.months
-        cohort_start_end = (cohort_start + 1.month).beginning_of_month
+      0.upto(@number_of_weeks) do |week|
+        cohort_start = first_cohort_week + week.weeks
+        cohort_start_end = (cohort_start + 1.week).beginning_of_week
 
         cohort_users = @user_class.where(created_at: cohort_start..cohort_start_end)
 
@@ -38,28 +38,39 @@ module RetentionMagic
         @graphs[:activation][:one_activation][cohort_start] = cohort_users.where("#{activation_fields_for_query} = 1").count
         @graphs[:activation][:five_activations][cohort_start] = cohort_users.where("#{activation_fields_for_query} >= 5").count
 
-        cohort_start_label = cohort_start.strftime("%h %y")
+        cohort_start_label = cohort_start.strftime("w%U %Y")
         @graphs[:retention][cohort_start_label] = {}
         cohort_user_ids = cohort_users.pluck(:id)
+        cohort_size = cohort_users.count
 
-        -1.upto((Date.today.year * 12 + Date.today.month) - (cohort_start.year * 12 + cohort_start.month) - 1) do |month|
-          retention_month = (cohort_start + month.months).beginning_of_month
-          retention_month_end = (retention_month + 1.month).beginning_of_month
+        difference_in_days_between_now_and_cohort_start = (today.beginning_of_week - cohort_start.to_date).to_i
+        number_of_weeks_in_this_cohort = difference_in_days_between_now_and_cohort_start / 7
 
-          records_per_user = {}
+        0.upto(number_of_weeks_in_this_cohort) do |week|
+          retention_week = (cohort_start + week.weeks).beginning_of_week
+          if week == 0
+            @graphs[:retention][cohort_start_label][retention_week] = cohort_size
+          else
+            retention_week_end = (retention_week + 1.week).beginning_of_week
 
-          retention_models.each do |model|
-            count_per_user = model.where(user_id: cohort_user_ids).where(created_at: retention_month..retention_month_end).group("user_id").count
-            count_per_user.each do |uid, count|
-              records_per_user[uid] ||= 0
-              records_per_user[uid] += count
+            records_per_user = {}
+
+            retention_models.each do |model|
+              count_per_user = model.where(user_id: cohort_user_ids).where(created_at: retention_week..retention_week_end).group("user_id").count
+              count_per_user.each do |uid, count|
+                records_per_user[uid] ||= 0
+                records_per_user[uid] += count
+              end
+            end
+
+            if cohort_user_ids.empty?
+              @graphs[:retention][cohort_start_label][retention_week] = 0
+            else
+              @graphs[:retention][cohort_start_label][retention_week] = records_per_user.keys.size
             end
           end
-
-          @graphs[:retention][cohort_start_label][retention_month] = records_per_user.keys.size
         end
       end
-
 
     end
   end

--- a/app/views/retention_magic/graphs/index.html.erb
+++ b/app/views/retention_magic/graphs/index.html.erb
@@ -24,15 +24,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">Cohorts</div>
         <div class="panel-body">
-          <%= @number_of_months %>
-        </div>
-      </div>
-    </div>
-    <div class="col-xs-6 col-sm-3">
-      <div class="panel panel-default">
-        <div class="panel-heading">First Cohort</div>
-        <div class="panel-body">
-          <%= @first_cohort %>
+          <%= @number_of_weeks %> weeks
         </div>
       </div>
     </div>
@@ -40,7 +32,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">Current Cohort</div>
         <div class="panel-body">
-          <%= @current_cohort %>
+          <%= @current_cohort_label %>
         </div>
       </div>
     </div>
@@ -78,7 +70,7 @@
       <h3 class="panel-title">Retention</h3>
     </div>
     <div class="panel-body">
-      <%= area_chart(@graphs[:retention].map { |k,v| {name: k, data: v}}, library: { legend: { position: "bottom" } } ) %>
+      <%= area_chart(@graphs[:retention].map { |k,v| {name: k, data: v}}, stacked: true, library: { bar: { groupWidth: "98%" }, legend: { position: "bottom" } } ) %>
 
     </div>
   </div>

--- a/app/views/retention_magic/graphs/index.html.erb
+++ b/app/views/retention_magic/graphs/index.html.erb
@@ -53,7 +53,7 @@
           data: @graphs[:activation][:five_activations]
         },
         {
-          name: "One interaction",
+          name: "<= 5 interactions",
           data: @graphs[:activation][:one_activation]
         },
         {

--- a/lib/retention_magic.rb
+++ b/lib/retention_magic.rb
@@ -6,6 +6,7 @@ module RetentionMagic
   end
   mattr_accessor :activation_counter_columns do
     []
+  end
   mattr_accessor :retention_models do
     []
   end


### PR DESCRIPTION
This PR groups metrics by week instead of months and makes the first "Activation" graph relative instead of absolute numbers.

Screenshot:

![schermafbeelding 2016-01-27 om 14 48 02](https://cloud.githubusercontent.com/assets/42268/12615510/68cdbbe2-c506-11e5-81db-8daf4c3db765.png)
